### PR TITLE
feat: react-query 초기 설정, 모달 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,34 +10,12 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>React App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,22 @@ import { RecoilRoot } from 'recoil';
 import { Routes, Route, BrowserRouter } from 'react-router-dom';
 import DetailPetPage from 'pages/DetailPetPage';
 import Home from 'pages/Home';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 function App() {
   return (
-    <RecoilRoot>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/pet/:id" element={<DetailPetPage />} />
-        </Routes>
-      </BrowserRouter>
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/pet/:id" element={<DetailPetPage />} />
+          </Routes>
+        </BrowserRouter>
+      </RecoilRoot>
+    </QueryClientProvider>
   );
 }
 

--- a/src/commons/ImageModal.tsx
+++ b/src/commons/ImageModal.tsx
@@ -1,0 +1,15 @@
+interface ModalProps {
+  onClose: () => void;
+  imageUrl: string;
+}
+
+const ImageModal = ({ onClose, imageUrl }: ModalProps) => {
+  return (
+    <div className="w-screen h-screen fixed top-0 left-0 flex justify-center items-center bg-black bg-opacity-50">
+      <button onClick={onClose}>X</button>
+      <img src={imageUrl} alt="" />
+    </div>
+  );
+};
+
+export default ImageModal;

--- a/src/commons/ModalPortal.tsx
+++ b/src/commons/ModalPortal.tsx
@@ -1,0 +1,14 @@
+import ReactDOM from 'react-dom';
+
+interface ModalPortalProps {
+  children: React.ReactNode;
+}
+
+const ModalPortal = ({ children }: ModalPortalProps) => {
+  const el = document.getElementById('modal-root');
+  if (!el) return null;
+
+  return ReactDOM.createPortal(children, el);
+};
+
+export default ModalPortal;

--- a/src/components/molecules/VDetailPetInfo.tsx
+++ b/src/components/molecules/VDetailPetInfo.tsx
@@ -10,7 +10,7 @@ const VDetailPetInfo = (data: MockDetailPetInfoProps) => {
           <div className="w-28">
             <span className="font-bold">나이</span> {data.age}{' '}
           </div>
-          <div className="w-52">
+          <div className="w-60">
             <span className="font-bold">성별</span> {data.sex}
           </div>
         </div>
@@ -19,7 +19,7 @@ const VDetailPetInfo = (data: MockDetailPetInfoProps) => {
           <div className="w-28">
             <span className="font-bold">몸무게</span> {data.weight}kg{' '}
           </div>
-          <div className="w-52">
+          <div className="w-60">
             <span className="font-bold">분양지역</span> 광주북구동물보호소
             <br />
             <span className="text-xs font-bold text-yellow-600">
@@ -39,7 +39,7 @@ const VDetailPetInfo = (data: MockDetailPetInfoProps) => {
             <span className="font-bold">백신접종</span>
             {` ${data.vaccinationStatus}`}{' '}
           </div>
-          <div className="w-52">
+          <div className="w-60">
             <span className="font-bold">중성화</span>
             {` ${data.neutralizationStatus}`}
           </div>
@@ -50,7 +50,7 @@ const VDetailPetInfo = (data: MockDetailPetInfoProps) => {
             <span className="font-bold">입양 여부</span>
             {` ${data.adoptionStatus}`}{' '}
           </div>
-          <div className="w-52">
+          <div className="w-60">
             <span className="font-bold">보호종료일</span>
             {` ${data.protectionExpirationDate}`}
           </div>

--- a/src/components/organisms/DetailPetData.tsx
+++ b/src/components/organisms/DetailPetData.tsx
@@ -1,24 +1,25 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import StringWithLineBreak from 'components/atoms/StringWithLineBrake';
+import { useQuery } from '@tanstack/react-query';
 import VDetailPetData, {
   MockDetailPetInfoProps,
   RadarChartProps,
 } from './VDetailPetData';
-// import { useQuery } from '@tanstack/react-query';
 
 const DetailPetData = () => {
   const params = useParams();
+  const petId = params.id;
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
+
   // const { data } = useQuery({
   //   queryKey: ['pet', petId],
   //   queryFn: () => {
-  //     return fetch(`http://localhost:8080/pet/${petId}`).then((res) =>
-  //       res.json(),
-  //     );
+  //     return fetch(
+  //       `http://ec2-3-37-14-140.ap-northeast-2.compute.amazonaws.com/api/short-forms`,
+  //     ).then((res) => res.json());
   //   },
   // });
-
   /*
   {
   "shelterId" : 1,

--- a/src/components/organisms/DetailPetData.tsx
+++ b/src/components/organisms/DetailPetData.tsx
@@ -11,6 +11,7 @@ const DetailPetData = () => {
   const params = useParams();
   const petId = params.id;
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
+  const [modal, setModal] = useState(false);
 
   // const { data } = useQuery({
   //   queryKey: ['pet', petId],
@@ -83,6 +84,10 @@ const DetailPetData = () => {
   const vDetailPetDataProps = {
     radarChartProps,
     mockDetailPetInfoProps: mockDetailPetInfo,
+    modal,
+    setModalOpen: () => setModal(true),
+    setModalClose: () => setModal(false),
+    imageUrl: mockDetailPetInfo.profileImageUrl,
   };
 
   return <VDetailPetData {...vDetailPetDataProps} />;

--- a/src/components/organisms/VDetailPetData.tsx
+++ b/src/components/organisms/VDetailPetData.tsx
@@ -1,5 +1,7 @@
 import RadarChart, { PolygonProfile } from 'components/atoms/RadarChart';
 import DetailPetInfo from 'components/molecules/DetailPetInfo';
+import ModalPortal from 'commons/ModalPortal';
+import ImageModal from 'commons/ImageModal';
 
 export interface RadarChartProps {
   setCanvas: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
@@ -29,16 +31,31 @@ export interface MockDetailPetInfoProps {
 interface Props {
   mockDetailPetInfoProps: MockDetailPetInfoProps;
   radarChartProps: RadarChartProps;
+  modal: boolean;
+  setModalOpen: () => void;
+  setModalClose: () => void;
+  imageUrl: string;
 }
 
-const VDetailPetData = ({ mockDetailPetInfoProps, radarChartProps }: Props) => {
+const VDetailPetData = ({
+  mockDetailPetInfoProps,
+  radarChartProps,
+  modal,
+  setModalOpen,
+  setModalClose,
+  imageUrl,
+}: Props) => {
   return (
     <div className="flex min-w-[375px] items-center flex-col justify-center md:flex-row">
       <img
         className="w-1/2 h-1/2"
         src={mockDetailPetInfoProps.profileImageUrl}
         alt="z"
+        onClick={setModalOpen}
       />
+      <ModalPortal>
+        {modal && <ImageModal imageUrl={imageUrl} onClose={setModalClose} />}
+      </ModalPortal>
       <div className="flex flex-col items-center">
         <DetailPetInfo {...mockDetailPetInfoProps} />
         <RadarChart {...radarChartProps} />


### PR DESCRIPTION
- React-query 사용을 위해 App.tsx에 QueryClientProvider 를 감싸주었습니다.
- portal을 통한 모달 구현을 위해 index.html에 id="modal-root" 인 div를 하나 생성하였습니다.
- commons 폴더에 모달 구현해두었습니다.
- /pet/:id 페이지에서 시험적으로 이미지 전용 모달을 구현해두었습니다.