### PR TITLE
fix: 종 카테고리 내부 상단 잘리던 현상 고침

### DIFF
--- a/src/commons/CategoryModal.tsx
+++ b/src/commons/CategoryModal.tsx
@@ -66,7 +66,7 @@ const CategoryModal = ({
       onClick={handleModalOutsideClick}
       className="w-screen h-screen fixed top-0 left-0 flex justify-center items-center bg-black bg-opacity-50"
     >
-      <div className="flex flex-col w-3/5 h-4/5 fixed bg-white rounded-md overflow-auto">
+      <div className="w-3/5 h-4/5 bg-white rounded-md overflow-auto">
         <div className="flex justify-between p-5">
           <div className="flex gap-3">
             <button

--- a/src/components/molecules/VCategoryModalList.tsx
+++ b/src/components/molecules/VCategoryModalList.tsx
@@ -30,10 +30,13 @@ const VCatetegoryModalList = (props: VCategoryModalListProps) => {
   return (
     <>
       {speciesOrRegion === 'species' && (
-        <div className="grid grid-cols-1 justify-items-center content-around h-full md:grid-cols-2">
+        <div className="grid grid-cols-1 h-full md:grid-cols-2">
           {speciesList.map((species, index) => {
             return (
-              <div key={species} className="flex flex-col items-center">
+              <div
+                key={species}
+                className="flex flex-col items-center justify-center"
+              >
                 <button
                   onClick={() => handleSpeciesClick(species)}
                   className="w-40 h-40 md:w-52 md:h-52 lg:w-72 lg:h-72 border shadow rounded-lg hover:bg-gray-100"


### PR DESCRIPTION
사진과 같은 이슈가 있어서 정렬 방식을 변경했습니다.

![image](https://github.com/Step3-kakao-tech-campus/Team16_FE/assets/77186082/2bd6249d-1b85-4e50-aed9-11b9655cc0a4)
