### PR TITLE
feat: 등록하기, 펫 상세조회 페이지 api 연동 확인

### DIFF
--- a/src/pages/detailPet/DetailPetData.tsx
+++ b/src/pages/detailPet/DetailPetData.tsx
@@ -13,14 +13,20 @@ const DetailPetData = () => {
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
   const [modal, setModal] = useState(false);
 
-  // const { data } = useQuery({
-  //   queryKey: ['pet', petId],
-  //   queryFn: () => {
-  //     return fetch(
-  //       `${process.env.REACT_APP_URI}/short-forms`,
-  //     ).then((res) => res.json());
-  //   },
-  // });
+  const { data } = useQuery({
+    queryKey: ['pet', petId],
+    queryFn: () => {
+      return fetch(`${process.env.REACT_APP_URI}/pet/${petId}`).then((res) =>
+        res.json(),
+      );
+    },
+    onSuccess: (res) => {
+      console.log(res);
+    },
+    onError: (err) => {
+      console.log(err);
+    },
+  });
   /*
   {
   "shelterInfo" : {

--- a/src/pages/detailPet/DetailPetData.tsx
+++ b/src/pages/detailPet/DetailPetData.tsx
@@ -13,63 +13,30 @@ const DetailPetData = () => {
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
   const [modal, setModal] = useState(false);
 
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['pet', petId],
     queryFn: () => {
       return fetch(`${process.env.REACT_APP_URI}/pet/${petId}`).then((res) =>
         res.json(),
       );
     },
-    onSuccess: (res) => {
-      console.log(res);
-    },
-    onError: (err) => {
-      console.log(err);
-    },
   });
-
+  if (isLoading) return <div>로딩중</div>;
   const labels = ['귀여움', '침착함', '유머감각', '외모', '의젓함'];
 
-  const mockDetailPetInfo: MockDetailPetInfoProps = {
-    shelterInfo: {
-      id: 1,
-      name: '광주어찌고보호소',
-      contact: '010-2312-2146',
-    },
-    name: '뽀삐',
-    age: '3살',
-    sex: 'Male',
-    weight: 5,
-    description: StringWithLineBreak(
-      '뽀삐는 귀여움이 넘치는 강아지입니다. \n착하게 말도 잘 듣고요\n자신의 일을 묵묵히 하는 타입입니다.\n다 크면 10kg 넘을 듯해요.\n개농장에서구조했슴',
-    ),
-    protectionExpirationDate: '2023-10-25',
-    vaccinationStatus: 'YES',
-    neutralizationStatus: 'YES',
-    adoptionStatus: 'NO',
-    profileImageUrl: '/assets/images/logo512.png',
-    size: '수박만함',
-    polygonProfile: {
-      intelligence: 1,
-      affinity: 3,
-      athletic: 4,
-      adaptability: 3,
-      activeness: 2,
-    },
-  };
   const radarChartProps: RadarChartProps = {
     setCanvas,
     width: 400,
     height: 400,
     canvas,
     labels,
-    data: mockDetailPetInfo.polygonProfile,
+    data: data.response.petPolygonProfileDto,
     willAnimate: true,
   };
 
   const vDetailPetDataProps = {
     radarChartProps,
-    mockDetailPetInfoProps: mockDetailPetInfo,
+    mockDetailPetInfoProps: data.response,
     modal,
     handleModalImageClick: () => setModal(true),
     handleModalCloseClick: () => setModal(false),
@@ -78,7 +45,7 @@ const DetailPetData = () => {
         setModal(false);
       }
     },
-    imageUrl: mockDetailPetInfo.profileImageUrl,
+    imageUrl: data.response.profileImageUrl,
   };
 
   return <VDetailPetData {...vDetailPetDataProps} />;

--- a/src/pages/detailPet/DetailPetData.tsx
+++ b/src/pages/detailPet/DetailPetData.tsx
@@ -2,10 +2,7 @@ import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import StringWithLineBreak from 'commons/StringWithLineBreak';
 import { useQuery } from '@tanstack/react-query';
-import VDetailPetData, {
-  MockDetailPetInfoProps,
-  RadarChartProps,
-} from './VDetailPetData';
+import VDetailPetData, { RadarChartProps } from './VDetailPetData';
 
 const DetailPetData = () => {
   const params = useParams();
@@ -36,7 +33,7 @@ const DetailPetData = () => {
 
   const vDetailPetDataProps = {
     radarChartProps,
-    mockDetailPetInfoProps: data.response,
+    detailPetInfoProps: data.response,
     modal,
     handleModalImageClick: () => setModal(true),
     handleModalCloseClick: () => setModal(false),

--- a/src/pages/detailPet/DetailPetData.tsx
+++ b/src/pages/detailPet/DetailPetData.tsx
@@ -27,34 +27,6 @@ const DetailPetData = () => {
       console.log(err);
     },
   });
-  /*
-  {
-  "shelterInfo" : {
-		"id" : 1,
-	  "name" : "광주어찌고보호소",
-	  "contact" : "010-2312-2146",
-	}
-  "name": "멍멍이",
-  "age": "0년6개월",
-  "type": "DOG",
-  "sex": "FEMALE",
-  "weight": 5.35,
-  "description": "귀여운 강아지입니다.",
-  "protectionExpirationDate": "2023-10-25", // 보호만료일 null 가능
-  "vaccinationStatus": "YES",
-  "neutralizationStatus": "YES",
-  "adoptionStatus": "NO",
-  "profileImageUrl": "https://...",
-  "size": "수박만함",
-  "polygonProfile": { // 1 ~ 5 정수
-    "intelligence": 1, // "영리함 점수"
-    "affinity": 1, // "친화력 점수",
-    "athletic": 1, // "운동신경 점수",
-    "adaptability": 1, //"적응력 점수",
-    "activeness": 1, // "활발함 점수"
-  }  
- }
- */
 
   const labels = ['귀여움', '침착함', '유머감각', '외모', '의젓함'];
 

--- a/src/pages/detailPet/DetailPetInfo.tsx
+++ b/src/pages/detailPet/DetailPetInfo.tsx
@@ -1,7 +1,7 @@
-import { MockDetailPetInfoProps } from 'pages/detailPet/VDetailPetData';
+import { DetailPetInfoProps } from 'pages/detailPet/VDetailPetData';
 import VDetailPetInfo from './VDetailPetInfo';
 
-const DetailPetInfo = (data: MockDetailPetInfoProps) => {
+const DetailPetInfo = (data: DetailPetInfoProps) => {
   return <VDetailPetInfo {...data} />;
 };
 

--- a/src/pages/detailPet/VDetailPetData.tsx
+++ b/src/pages/detailPet/VDetailPetData.tsx
@@ -12,7 +12,7 @@ export interface RadarChartProps {
   data: PolygonProfile;
   willAnimate: boolean;
 }
-export interface MockDetailPetInfoProps {
+export interface DetailPetInfoProps {
   shelterInfo: {
     id: number;
     name: string;
@@ -33,7 +33,7 @@ export interface MockDetailPetInfoProps {
 }
 
 interface Props {
-  mockDetailPetInfoProps: MockDetailPetInfoProps;
+  detailPetInfoProps: DetailPetInfoProps;
   radarChartProps: RadarChartProps;
   modal: boolean;
   handleModalImageClick: () => void;
@@ -43,7 +43,7 @@ interface Props {
 }
 
 const VDetailPetData = ({
-  mockDetailPetInfoProps,
+  detailPetInfoProps,
   radarChartProps,
   modal,
   handleModalImageClick,
@@ -55,7 +55,7 @@ const VDetailPetData = ({
     <div className="flex min-w-[375px] items-center flex-col justify-center md:flex-row">
       <img
         className="relative w-96 cursor-pointer lg:mr-20"
-        src={mockDetailPetInfoProps.profileImageUrl}
+        src={detailPetInfoProps.profileImageUrl}
         alt="z"
         onClick={handleModalImageClick}
       />
@@ -69,7 +69,7 @@ const VDetailPetData = ({
         )}
       </ModalPortal>
       <div className="flex flex-col items-center">
-        <DetailPetInfo {...mockDetailPetInfoProps} />
+        <DetailPetInfo {...detailPetInfoProps} />
         <RadarChart {...radarChartProps} />
       </div>
     </div>

--- a/src/pages/detailPet/VDetailPetInfo.tsx
+++ b/src/pages/detailPet/VDetailPetInfo.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
-import { MockDetailPetInfoProps } from 'pages/detailPet/VDetailPetData';
+import { DetailPetInfoProps } from 'pages/detailPet/VDetailPetData';
 
-const VDetailPetInfo = (data: MockDetailPetInfoProps) => {
+const VDetailPetInfo = (data: DetailPetInfoProps) => {
   return (
     <div>
       <h2 className="text-3xl mb-10">{data.name}</h2>

--- a/src/pages/register/RegisterHeader.tsx
+++ b/src/pages/register/RegisterHeader.tsx
@@ -17,8 +17,8 @@ interface PetPostProps {
   size: string;
   sex: string;
   vaccinationStatus: string;
-  adoptionStatus: boolean;
-  neutralizationStatus: boolean;
+  adoptionStatus: string;
+  neutralizationStatus: string;
   description: string;
   petPolygonProfileDto: {
     intelligence: number;
@@ -27,18 +27,19 @@ interface PetPostProps {
     adaptability: number;
     activeness: number;
   };
+  protectionExpirationDate: string;
 }
 
 const mockPetData: PetPostProps = {
-  name: '이렇게 긴 문장도 받을 수 있나요? 얼마나 긴 문장까지 자바에서 받을 수 있을까요? 이렇게 긴 문장도 받을 수 있나요? 얼마나 긴 문장까지 자바에서 받을 수 있을까요? 이렇게 긴 문장도 받을 수 있나요? 얼마나 긴 문장까지 자바에서 받을 수 있을까요? 이렇게 긴 문장도 받을 수 있나요? 얼마나 긴 문장까지 자바에서 받을 수 있을까요? 이렇게 긴 문장도 받을 수 있나요? 얼마나 긴 문장까지 자바에서 받을 수 있을까요? ',
-  age: '1',
+  name: '뽀삐',
+  age: '1년1개월',
   type: 'DOG',
   weight: 1,
   size: '제가 보낸 요청',
-  sex: 'string',
-  vaccinationStatus: '안녕하세요',
-  adoptionStatus: false,
-  neutralizationStatus: false,
+  sex: 'MALE',
+  vaccinationStatus: 'YES',
+  adoptionStatus: 'YES',
+  neutralizationStatus: 'YES',
   description: '잘 받아졌을까요',
   petPolygonProfileDto: {
     intelligence: 1,
@@ -47,6 +48,7 @@ const mockPetData: PetPostProps = {
     adaptability: 1,
     activeness: 1,
   },
+  protectionExpirationDate: '2021-10-25',
 };
 
 const RegisterHeader = () => {
@@ -70,30 +72,38 @@ const RegisterHeader = () => {
 
   // 등록하기 관련
   const postPet = async (formData: FormData) => {
-    const res = await fetch('http://localhost:8080/api/v1/pets', {
+    const res = await fetch(`${process.env.REACT_APP_URI}/pet`, {
       method: 'POST',
       body: formData,
     });
     return res.json();
   };
-  const { data, mutate, isError, isLoading, isSuccess } = useMutation(postPet);
+  const { data, mutate, isError, isLoading, isSuccess } = useMutation(postPet, {
+    onError: (err: unknown) => {
+      console.log(err);
+    },
+    onSuccess: (res) => {
+      console.log(res);
+    },
+  });
   const handleRegisterButtonClick = async () => {
     if (!selectedImageFile || !selectedVideoFile || registerPetData.isComplete)
       return;
     // destructuring을 이용해서 isComplete를 제외한 나머지 데이터를 rest에 담음
     // api에 보낼 데이터는 rest + image + video
-    const { isComplete, ...rest } = registerPetData;
+    // const { isComplete, ...rest } = registerPetData;
+    console.log(mockPetData);
     const formData = new FormData();
-    formData.append('video', selectedVideoFile);
-    formData.append('image', selectedImageFile);
+    formData.append('profileVideo', selectedVideoFile);
+    formData.append('profileImage', selectedImageFile);
     formData.append(
-      'key',
-      new Blob([JSON.stringify(rest)], {
+      'petInfo',
+      new Blob([JSON.stringify(mockPetData)], {
         type: 'application/json',
       }),
     );
     try {
-      const res = await mutate(formData);
+      const res = mutate(formData);
       console.log(res);
     } catch (err: unknown) {
       console.log(err);


### PR DESCRIPTION
## 구현된 부분
- 두 페이지 모두 백엔드 api와 연동 확인
  - 회원가입 -> 로그인 -> 등록 -> 해당 동물 받아오기 및 사진 띄우기까지 확인했습니다.
- 필요없는 주석 일부 삭제
  - 나머지는 추후 페이지 완성 시에 삭제하겠습니다.

## 미구현 부분
- 등록하기 페이지에서 확인용 `console.log`를 아직 안 지웠습니다.

## 고민
- X