### PR TITLE
feat: 로그인, 회원가입 백엔드 API 연결 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^18.2.22",
         "@types/react-dom": "^18.2.7",
         "react": "^18.2.0",
+        "react-cookie": "^6.1.1",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
@@ -4046,6 +4047,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.2.tgz",
+      "integrity": "sha512-DBpRoJGKJZn7RY92dPrgoMew8xCWc2P71beqsjyhEI/Ds9mOyVmBwtekyfhpwFIVt1WrxTonFifiOZ62V8CnNA=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.3",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.3.tgz",
@@ -4097,6 +4103,15 @@
       "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.3.tgz",
+      "integrity": "sha512-Wny3a2UXn5FEA1l7gc6BbpoV5mD1XijZqgkp4TRgDCDL5r3B5ieOFGUX5h3n78Tr1MEG7BfvoM8qeztdvNU0fw==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -9075,6 +9090,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -14771,6 +14799,19 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/react-cookie": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-6.1.1.tgz",
+      "integrity": "sha512-fuFRpf8LH6SfmVMowDUIRywJF5jAUDUWrm0EI5VdXfTl5bPcJ7B0zWbuYpT0Tvikx7Gs18MlvAT+P+744dUz2g==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-daum-postcode": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
@@ -17060,6 +17101,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.1.1.tgz",
+      "integrity": "sha512-33S9x3CpdUnnjwTNs2Fgc41WGve2tdLtvaK2kPSbZRc5pGpz2vQFbRWMxlATsxNNe/Cy8SzmnmbuBM85jpZPtA==",
+      "dependencies": {
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "react": "^18.2.0",
+    "react-cookie": "^6.1.1",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",

--- a/src/commons/PostCode.tsx
+++ b/src/commons/PostCode.tsx
@@ -43,6 +43,7 @@ const Postcode = () => {
 
   return (
     <button
+      type="button"
       className="bg-brand-color text-white rounded  min-w-[120px] p-1"
       onClick={handleClick}
     >

--- a/src/commons/cookie/cookie.ts
+++ b/src/commons/cookie/cookie.ts
@@ -1,0 +1,16 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const setCookie = (name: string, value: string, option?: any) => {
+  return cookies.set(name, value, { ...option });
+};
+
+// 토큰 값 이용
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};
+
+export const removeCookie = (name: string) => {
+  return cookies.remove(name);
+};

--- a/src/commons/cookie/getUser.ts
+++ b/src/commons/cookie/getUser.ts
@@ -1,0 +1,13 @@
+import { getCookie, removeCookie } from './cookie';
+
+export const getLoginState = () => {
+  const token = getCookie('loginToken');
+  if (token) {
+    return '로그아웃';
+  }
+  return '로그인';
+};
+
+export const removeUser = () => {
+  removeCookie('loginToken');
+};

--- a/src/layouts/VGNB.tsx
+++ b/src/layouts/VGNB.tsx
@@ -1,4 +1,5 @@
 import LogoButton from 'commons/LogoButton';
+import { getLoginState, removeUser } from 'commons/cookie/getUser';
 import { Link } from 'react-router-dom';
 
 export interface VGNBProps {
@@ -36,8 +37,11 @@ const VGNB = (props: VGNBProps) => {
           <div className="lg:hidden w-full flex flex-col items-center text-xl gap-8">
             <div className="flex justify-center w-full gap-2">
               <Link to="/login">
-                <button className="border border-2 box-border border-brand-color text-brand-color rounded-md w-28 py-1">
-                  로그인
+                <button
+                  className="border border-2 box-border border-brand-color text-brand-color rounded-md w-28 py-1"
+                  onClick={removeUser}
+                >
+                  {getLoginState()}
                 </button>
               </Link>
               <Link to="/signup">

--- a/src/layouts/VLargeGNB.tsx
+++ b/src/layouts/VLargeGNB.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import LogoButton from 'commons/LogoButton';
+import { getLoginState, removeUser } from 'commons/cookie/getUser';
 
 export interface VLargeGNBProps {
   handleCategoryButtonClick: () => void;
@@ -61,8 +62,11 @@ const VLargeGNB = (props: VLargeGNBProps) => {
 
         <div className="flex gap-4 font-bold">
           <Link to="/login">
-            <button className="border border-2 box-content border-brand-color text-brand-color rounded-md py-1 px-4 transition duration-300 hover:bg-brand-color hover:text-white">
-              로그인
+            <button
+              className="border border-2 box-content border-brand-color text-brand-color rounded-md py-1 px-4 transition duration-300 hover:bg-brand-color hover:text-white"
+              onClick={removeUser}
+            >
+              {getLoginState()}
             </button>
           </Link>
           <Link to="/signup">

--- a/src/pages/login/LoginInputForm.tsx
+++ b/src/pages/login/LoginInputForm.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { useRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
 import { shelterLoginState } from 'recoil/shelterState';
 import VLoginInputForm from './VLoginInputForm';
+import { setCookie } from '../../commons/cookie/cookie';
 
 const LoginInputForm = () => {
   const [userInfo, setUserInfo] = useRecoilState(shelterLoginState);
@@ -9,7 +11,7 @@ const LoginInputForm = () => {
   const [isPasswordEmpty, setIsPasswordEmpty] = useState(false);
   const [errorText, setErrorText] = useState('이메일을 입력해주세요');
 
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
 
   const emailValidate = (text: string) => {
     const emailReg = /^[\w.-]+@[\w.-]+\.\w+$/g; // email형식
@@ -42,12 +44,24 @@ const LoginInputForm = () => {
         email: userInfo.email,
         password: userInfo.password,
       }),
-    }).then((res) => {
-      console.log(res);
-      // if (res.status === 200) {
-      //   navigate('/');
-      // }
-    });
+    })
+      .then((res) => {
+        const jwtToken = res.headers.get('Authorization');
+        if (jwtToken) {
+          const slicedToken = jwtToken.split(' ')[1];
+          setCookie('loginToken', slicedToken);
+        } else {
+          console.log('Token이 Null');
+        }
+
+        return res.json();
+      })
+      .then((data) => {
+        if (data.success) {
+          // const token = getCookie('loginToken');
+          navigate('/');
+        }
+      });
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/signUp/SignupInputForm.tsx
+++ b/src/pages/signUp/SignupInputForm.tsx
@@ -19,9 +19,13 @@ const SignupInputForm = () => {
       }),
     })
       .then((res) => {
-        res.json();
+        return res.json();
       })
-      .then((data) => console.log('Data', data));
+      .then((data) => {
+        if (!data.success) {
+          alert('이메일 중복되었음'); // 이 부분 어떻게 하죠?
+        }
+      });
   };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/signUp/SignupInputForm.tsx
+++ b/src/pages/signUp/SignupInputForm.tsx
@@ -9,17 +9,37 @@ export interface EmailConfirmProps {
   checked: boolean;
 }
 
-// confirm state의 경우, 일치하지 않을 때 false
+interface EmailValidProps {
+  validText: string;
+  inValidText: string;
+  emailConfirmObj: EmailConfirmProps;
+}
+
 const SignupInputForm = () => {
   const [shelterInfo, setShelterInfo] = useRecoilState(shelterSignupState);
+  // confirm state의 경우, 일치하지 않을 때 false
+  // isValid: 중복검사 통과했는가?
+  // checked: 이메일 중복 검사를 했는가?
   const [emailConfirm, setEmailConfirm] = useState<EmailConfirmProps>({
     isValid: true,
     checked: false,
   });
   const [passwordConfirm, setPasswordConfirm] = useState(true);
   const { isValid, checked } = emailConfirm;
+  const [emailValidText, setEmailValidText] = useState('');
+  const [emailInValidText, setEmailInValidText] = useState('');
 
   const navigate = useNavigate();
+
+  const getEmailValidText = ({
+    validText,
+    inValidText,
+    emailConfirmObj,
+  }: EmailValidProps) => {
+    setEmailValidText(validText);
+    setEmailInValidText(inValidText);
+    setEmailConfirm(emailConfirmObj);
+  };
 
   const duplicateCheck = () => {
     // shelterInfo.email
@@ -37,16 +57,32 @@ const SignupInputForm = () => {
       })
       .then((data) => {
         if (!data.success) {
-          alert(data.error.message); // 이 부분 어떻게 하죠?
-          setEmailConfirm({
-            isValid: false,
-            checked: false,
+          getEmailValidText({
+            validText: '',
+            inValidText: data.error.message,
+            emailConfirmObj: {
+              isValid: false,
+              checked: false,
+            },
+          });
+        } else if (!shelterInfo.email) {
+          getEmailValidText({
+            validText: '',
+            inValidText: '',
+            // 안 넣으면 빈칸으로 공간 차지해서 이렇게 조건 넣어줌
+            emailConfirmObj: {
+              isValid: false,
+              checked: true,
+            },
           });
         } else {
-          alert('사용 가능합니다.');
-          setEmailConfirm({
-            isValid: true,
-            checked: true,
+          getEmailValidText({
+            validText: '사용 가능한 이메일입니다.',
+            inValidText: '',
+            emailConfirmObj: {
+              isValid: true,
+              checked: true,
+            },
           });
         }
       });
@@ -108,7 +144,7 @@ const SignupInputForm = () => {
         })
         .then((data) => {
           if (!data.success) {
-            // alert(data.error.message);
+            alert(data.error.message); // 이 부분은 주소 받는 거 때문에 그냥 텍스트만 넣기 애매함
             return;
           }
           navigate('/login');
@@ -124,6 +160,8 @@ const SignupInputForm = () => {
     passwordConfirm,
     isValid,
     checked,
+    emailValidText,
+    emailInValidText,
   };
 
   return <VSignupInputForm {...SignupInputFormProps} />;

--- a/src/pages/signUp/VSignupInputForm.tsx
+++ b/src/pages/signUp/VSignupInputForm.tsx
@@ -2,13 +2,15 @@ import AddressInputGroup from 'pages/signUp/AddressInputGroup';
 import InputGroup from 'commons/InputGroup';
 import React from 'react';
 
-interface Props {
+interface VSignupInputProps {
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   duplicateCheck: () => void;
   isValid: boolean;
   checked: boolean;
   passwordConfirm: boolean;
+  emailValidText: string;
+  emailInValidText: string;
 }
 
 const VSignupInputForm = ({
@@ -18,7 +20,9 @@ const VSignupInputForm = ({
   isValid,
   checked,
   passwordConfirm,
-}: Props) => {
+  emailValidText,
+  emailInValidText,
+}: VSignupInputProps) => {
   return (
     <form
       className="flex flex-col gap-4 w-full max-w-[400px]"
@@ -41,8 +45,11 @@ const VSignupInputForm = ({
           중복 확인
         </button>
       </div>
+      {checked && isValid && (
+        <div className="text-green-500">{emailValidText}</div>
+      )}
       {!checked && !isValid && (
-        <div className="text-red-500">이메일 형식을 확인해주세요.</div>
+        <div className="text-red-500">{emailInValidText}</div>
       )}
       <InputGroup
         id="password"

--- a/src/pages/signUp/VSignupInputForm.tsx
+++ b/src/pages/signUp/VSignupInputForm.tsx
@@ -6,14 +6,18 @@ interface Props {
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   duplicateCheck: () => void;
-  confirm: boolean;
+  isValid: boolean;
+  checked: boolean;
+  passwordConfirm: boolean;
 }
 
 const VSignupInputForm = ({
   handleChange,
   handleSubmit,
   duplicateCheck,
-  confirm,
+  isValid,
+  checked,
+  passwordConfirm,
 }: Props) => {
   return (
     <form
@@ -37,6 +41,9 @@ const VSignupInputForm = ({
           중복 확인
         </button>
       </div>
+      {!checked && !isValid && (
+        <div className="text-red-500">이메일 형식을 확인해주세요.</div>
+      )}
       <InputGroup
         id="password"
         name="비밀번호"
@@ -53,7 +60,7 @@ const VSignupInputForm = ({
         onChange={handleChange}
         autocomplete="new-password"
       />
-      {confirm && (
+      {!passwordConfirm && (
         <div className="text-red-500">비밀번호가 일치하지 않습니다.</div>
       )}
       <InputGroup


### PR DESCRIPTION
## 구현된 부분
- 로그인 페이지에서 로그인 성공 시 토큰을 쿠키에 저장하고 홈 화면으로 가도록 수정했습니다. 
- 회원가입 페이지에서 이메일 중복 확인에 대한 기능을 수정했습니다. 
   - 중복 확인에 대해 사용 가능 여부를 아래쪽에 안내 텍스트로 나타내도록 했습니다. 
   (가능한 경우, 초록색 글씨 / 불가능한 경우, 빨간색 글씨)
- GNB에서 쿠키 유무에 따라 로그인 버튼의 텍스트를 로그인, 로그아웃으로 보이도록 수정했습니다. 
- 우편번호 찾기 버튼을 눌렀을 때 handleSubmit이 작동하는 문제 해결했습니다. 

## 미구현된 부분
- handleSubmit으로 에러 텍스트를 나타내는 부분에서 모달창으로 할지, 그냥 alert를 쓸지 애매해서 고민중입니다. 

## 고민
- handleSubmit으로 에러 텍스트를 나타내는 부분에서 모달창으로 할지, 그냥 alert를 쓸지 애매해서 고민중입니다. 
- 쿠키에 저장한 토큰을 디코딩할 필요가 아직은 없을 것 같은데 그냥 저장만 하면 되겠죠??
   - 넣는다면 토큰 만료일 비교하는 것 정도일 것 같은데, 아직은 불필요해보여서 따로 구현은 안했습니다. 