### PR TITLE
fix: 특성 점수 부여하는 부분에서 버튼이 클릭되지 않는 문제 해결

### DIFF
--- a/src/pages/register/StatusScore.tsx
+++ b/src/pages/register/StatusScore.tsx
@@ -36,35 +36,35 @@ const StatusScore = ({ status, selectedOption, handleChange }: StatusProps) => {
           type="radio"
           value="1"
           className={getButtonColor('1')}
-          onChange={() => handleChange(status, '1')}
+          onClick={() => handleChange(status, '1')}
         />
         <Dash />
         <input
           type="radio"
           value="2"
           className={getButtonColor('2')}
-          onChange={() => handleChange(status, '2')}
+          onClick={() => handleChange(status, '2')}
         />
         <Dash />
         <input
           type="radio"
           value="3"
           className={getButtonColor('3')}
-          onChange={() => handleChange(status, '3')}
+          onClick={() => handleChange(status, '3')}
         />
         <Dash />
         <input
           type="radio"
           value="4"
           className={getButtonColor('4')}
-          onChange={() => handleChange(status, '4')}
+          onClick={() => handleChange(status, '4')}
         />
         <Dash />
         <input
           type="radio"
           value="5"
           className={getButtonColor('5')}
-          onChange={() => handleChange(status, '5')}
+          onClick={() => handleChange(status, '5')}
         />
         <span className="text-sm font-semibold mx-1">High</span>
       </div>

--- a/src/pages/register/StatusSelectGroup.tsx
+++ b/src/pages/register/StatusSelectGroup.tsx
@@ -20,18 +20,17 @@ const StatusSelectGroup = () => {
         setProfileStatus((prev) => ({
           ...prev,
           polygonProfile: {
-            ...polygonProfile,
+            ...prev.polygonProfile,
             intelligence: Number(option),
           },
         }));
-
         break;
       case 'affinity':
         setAffinityOption(option);
         setProfileStatus((prev) => ({
           ...prev,
           polygonProfile: {
-            ...polygonProfile,
+            ...prev.polygonProfile,
             affinity: Number(option),
           },
         }));
@@ -41,7 +40,7 @@ const StatusSelectGroup = () => {
         setProfileStatus((prev) => ({
           ...prev,
           polygonProfile: {
-            ...polygonProfile,
+            ...prev.polygonProfile,
             athletic: Number(option),
           },
         }));
@@ -51,7 +50,7 @@ const StatusSelectGroup = () => {
         setProfileStatus((prev) => ({
           ...prev,
           polygonProfile: {
-            ...polygonProfile,
+            ...prev.polygonProfile,
             adaptability: Number(option),
           },
         }));
@@ -61,7 +60,7 @@ const StatusSelectGroup = () => {
         setProfileStatus((prev) => ({
           ...prev,
           polygonProfile: {
-            ...polygonProfile,
+            ...prev.polygonProfile,
             activeness: Number(option),
           },
         }));


### PR DESCRIPTION
onChange로 되어있는 이벤트 핸들러를 onClick으로 변경했습니다.
점수 state 관리 부분에서 관리하는 state가 다르기 때문에 오류가 생길 수 있다는 피드백이 있어 수정했습니다.

resolves #92 