### PR TITLE
feat: 백엔드에서 받은 데이터만 표시하도록 변경

### DIFF
--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -142,7 +142,9 @@ const Map: React.FC = () => {
                 x,
                 y,
               };
-              searchedPlace.current.push(placeInfo);
+              if (data.length > searchedPlace.current.length) {
+                searchedPlace.current.push(placeInfo);
+              }
               bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
             }
 

--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -35,7 +35,6 @@ const Map: React.FC = () => {
       parseInt(place.id, 10),
     );
 
-    console.log(searchedPlaceIdArr);
     fetch(`${process.env.REACT_APP_URI}/shelter/filter`, {
       method: 'POST',
       body: JSON.stringify(searchedPlaceIdArr),
@@ -77,7 +76,6 @@ const Map: React.FC = () => {
       if (!currentPosition.lat || !currentPosition.lon) {
         return;
       }
-      console.log(currentPosition.lat, currentPosition.lon);
       window.kakao.maps.load(() => {
         const mapContainer = document.getElementById('map');
         const mapOption = {

--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -21,6 +21,7 @@ interface SearchedPlaceType {
   road_address_name: string;
   x: string;
   y: string;
+  isRegistered?: boolean;
 }
 
 const Map: React.FC = () => {
@@ -29,6 +30,32 @@ const Map: React.FC = () => {
     lat: 35.1759293,
     lon: 126.9149701,
   });
+  if (searchedPlace.current.length > 0) {
+    const searchedPlaceIdArr = searchedPlace.current.map((place) =>
+      parseInt(place.id, 10),
+    );
+
+    console.log(searchedPlaceIdArr);
+    fetch(`${process.env.REACT_APP_URI}/shelter/filter`, {
+      method: 'POST',
+      body: JSON.stringify(searchedPlaceIdArr),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((res) => {
+        console.log(res);
+      })
+      .then((data: any) => {
+        searchedPlace.current.forEach((place, index) => {
+          data?.forEach((shelter: any) => {
+            if (place.id === shelter.id) {
+              searchedPlace.current[index].isRegistered = true;
+            }
+          });
+        });
+      });
+  }
 
   useEffect(() => {
     // 현재 위치를 가져옵니다

--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable func-names */
@@ -26,6 +27,7 @@ interface SearchedPlaceType {
 
 const Map: React.FC = () => {
   const searchedPlace = useRef<SearchedPlaceType[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
   const [currentPosition, setCurrentPosition] = React.useState({
     lat: 35.1759293,
     lon: 126.9149701,
@@ -42,14 +44,17 @@ const Map: React.FC = () => {
         'Content-Type': 'application/json',
       },
     })
-      .then((res) => {
-        console.log(res);
-      })
+      .then((res) => res.json())
       .then((data: any) => {
         searchedPlace.current.forEach((place, index) => {
-          data?.forEach((shelter: any) => {
-            if (place.id === shelter.id) {
+          data?.response.forEach((shelter: any) => {
+            setIsLoading(false);
+            if (place.id === shelter.kakaoLocationId.toString()) {
               searchedPlace.current[index].isRegistered = true;
+              console.log(searchedPlace.current[index]);
+            } else {
+              searchedPlace.current[index].isRegistered = false;
+              console.log(searchedPlace.current[index]);
             }
           });
         });
@@ -115,9 +120,12 @@ const Map: React.FC = () => {
             const bounds = new kakao.maps.LatLngBounds();
 
             for (let i = 0; i < data.length; i += 1) {
+              console.log(data);
               if (
-                data[i].place_name === '광주광역시동물보호소' ||
-                data[i].place_name === '광주청소년일시보호소'
+                searchedPlace.current.some((place) => {
+                  console.log(place.id, data[i].id);
+                  return place.id === data[i].id && place.isRegistered;
+                })
               ) {
                 displayMarker2(data[i]);
               } else displayMarker(data[i]);
@@ -200,16 +208,45 @@ const Map: React.FC = () => {
             map.setCenter(marker.getPosition());
           });
         }
+        // searchedPlace.current 순환하며 isRegistered에 대해서 마커 스타일 변경하기
+        const imageSrc3 = '/assets/images/all.png';
+        const imageSize3 = new kakao.maps.Size(64, 69);
+        const markerImage3 = new kakao.maps.MarkerImage(imageSrc3, imageSize3);
+        function displayMarker3(place: any) {
+          // 마커를 생성하고 지도에 표시합니다
+          const marker = new kakao.maps.Marker({
+            map,
+            position: new kakao.maps.LatLng(place.y, place.x),
+            image: markerImage3,
+          });
+
+          // 마커에 클릭이벤트를 등록합니다
+          kakao.maps.event.addListener(marker, 'click', function () {
+            // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+            infowindow.setContent(
+              `<div style="padding:5px;font-size:12px;">${place.place_name}</div>`,
+            );
+            infowindow.open(map, marker);
+            // 중간 지점으로 이동
+            map.setCenter(marker.getPosition());
+          });
+        }
       });
     };
     mapScript.addEventListener('load', onLoadKakaoMap);
-  }, [currentPosition.lat, currentPosition.lon]);
+  }, [isLoading]);
 
   return (
     <div className="Map">
       <div id="map" className="w-96 h-96" />
-      <button onClick={() => console.log(searchedPlace.current)}>
-        검색된 장소들 콘솔에 출력하기
+      <button
+        onClick={() => {
+          searchedPlace.current?.forEach((place) => {
+            if (place.isRegistered) console.log(place);
+          });
+        }}
+      >
+        등록된 장소만 콘솔에 출력하기
       </button>
     </div>
   );

--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -51,10 +51,8 @@ const Map: React.FC = () => {
             setIsLoading(false);
             if (place.id === shelter.kakaoLocationId.toString()) {
               searchedPlace.current[index].isRegistered = true;
-              console.log(searchedPlace.current[index]);
             } else {
               searchedPlace.current[index].isRegistered = false;
-              console.log(searchedPlace.current[index]);
             }
           });
         });
@@ -120,10 +118,8 @@ const Map: React.FC = () => {
             const bounds = new kakao.maps.LatLngBounds();
 
             for (let i = 0; i < data.length; i += 1) {
-              console.log(data);
               if (
                 searchedPlace.current.some((place) => {
-                  console.log(place.id, data[i].id);
                   return place.id === data[i].id && place.isRegistered;
                 })
               ) {


### PR DESCRIPTION
## 구현된 부분
1. 반경 20km 이내에 있는 동물 보호소를 모두 탐색해서(id값만을) 배열에 담는다.
2. 백엔드한테 카카오맵 id값만 추출해서 배열로 보낸다.
3. 회원가입 과정에서 백엔드가 저장해뒀던 id값이랑 비교해서 일치하는 id가 있다면 해당 보호소는 돌려준다.
4. 20km이내에 있는 보호소와 백엔드에게서 돌려 받은 보호소의 id값을 비교한다.
5. 일치하면 애니모리에 등록된 보호소니까 다르게 표시한다.
   - 현재는 지도상에 강아지로 마커만 다르게 출력해뒀다.

## 미구현 부분
- 리스트
- 코드가 엄청나게 더럽다. 함수를 웬만하면 분리해서 관리해야겠다. 시험 끝나고 리팩토링 필수다.

## 고민
- X