### PR TITLE
feat: 수정하기 페이지 달력 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,11 @@ import SignupPage from 'pages/signUp/SignupPage';
 import UrgentListPage from 'pages/profileList/urgentList/UrgentListPage';
 import UpdatePage from 'pages/update/UpdatePage';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { refetchOnWindowFocus: false, refetchOnMount: false },
+  },
+});
 
 function App() {
   return (

--- a/src/pages/login/VLoginInputForm.tsx
+++ b/src/pages/login/VLoginInputForm.tsx
@@ -28,7 +28,7 @@ const VLoginInputForm = ({
         onChange={(e) => {
           handleChange(e);
         }}
-        autocomplete="email"
+        autocomplete="off"
       />
       {isEmailEmpty && <div className="text-red-500">{errorText}</div>}
       <InputGroup
@@ -39,7 +39,7 @@ const VLoginInputForm = ({
         onChange={(e) => {
           handleChange(e);
         }}
-        autocomplete="current-password"
+        autocomplete="off"
       />
       {isPasswordEmpty && (
         <div className="text-red-500">비밀번호를 입력해주세요.</div>

--- a/src/pages/register/Calendar.tsx
+++ b/src/pages/register/Calendar.tsx
@@ -255,16 +255,16 @@ const Calendar = ({ handleClick }: CalendarProps) => {
       </div>
 
       <table className="flex flex-col gap-2 font-medium">
-        <thead className="grid grid-cols-7 grid-rows-1 text-center">
+        <thead className="grid grid-cols-7 grid-rows-1">
           {dayOfWeek.map((row: string, index: number) => (
-            <tr key={index} className="weeks">
+            <tr key={index} className="weeks mx-auto">
               <td>{row}</td>
             </tr>
           ))}
         </thead>
         <tbody className="h-full grid gap-2">
           {calendarRows.map((row: JSX.Element[], index: number) => (
-            <tr key={index} className="text-center grid grid-cols-7 gap-2">
+            <tr key={index} className="text-center grid grid-cols-7">
               {row}
             </tr>
           ))}

--- a/src/pages/register/StatusSelectGroup.tsx
+++ b/src/pages/register/StatusSelectGroup.tsx
@@ -19,9 +19,9 @@ const StatusSelectGroup = () => {
         setIntelligenceOption(option);
         setProfileStatus((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
-            intelligence: Number(option),
+            intelligence: option,
           },
         }));
         break;
@@ -29,9 +29,9 @@ const StatusSelectGroup = () => {
         setAffinityOption(option);
         setProfileStatus((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
-            affinity: Number(option),
+            affinity: option,
           },
         }));
         break;
@@ -39,9 +39,9 @@ const StatusSelectGroup = () => {
         setAthleticOption(option);
         setProfileStatus((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
-            athletic: Number(option),
+            athletic: option,
           },
         }));
         break;
@@ -49,9 +49,9 @@ const StatusSelectGroup = () => {
         setAdaptabilityOption(option);
         setProfileStatus((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
-            adaptability: Number(option),
+            adaptability: option,
           },
         }));
         break;
@@ -59,9 +59,9 @@ const StatusSelectGroup = () => {
         setActivenessOption(option);
         setProfileStatus((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
-            activeness: Number(option),
+            activeness: option,
           },
         }));
         break;

--- a/src/pages/register/VDayModalInput.tsx
+++ b/src/pages/register/VDayModalInput.tsx
@@ -12,7 +12,7 @@ const VDayModalInput = ({ open, handleClick }: DayModalProps) => {
   const { protectionExpirationDate } = protectionDate;
 
   return (
-    <div className="flex justify-center items-center gap-2">
+    <div className="flex justify-center items-center gap-2 relative">
       <label htmlFor="day-modal" className="text-sm font-semibold">
         안락사 일자
       </label>
@@ -23,10 +23,11 @@ const VDayModalInput = ({ open, handleClick }: DayModalProps) => {
         type="text"
         placeholder="날짜를 선택해주세요."
         onClick={handleClick}
-        defaultValue={protectionExpirationDate}
-        autoComplete="date"
+        value={protectionExpirationDate}
+        autoComplete="off"
+        readOnly
       />
-      <dialog open={open} className="">
+      <dialog open={open} className="absolute top-10 mt-2">
         <Calendar handleClick={handleClick} />
       </dialog>
     </div>

--- a/src/pages/signUp/VSignupInputForm.tsx
+++ b/src/pages/signUp/VSignupInputForm.tsx
@@ -35,7 +35,7 @@ const VSignupInputForm = ({
           type="text"
           placeholder="이메일을 입력해주세요."
           onChange={handleChange}
-          autocomplete="email"
+          autocomplete="off"
         />
         <button
           type="button" // type을 버튼으로 지정해주면 handleSubmit이 작동하지 않음 -> onClick만 동작
@@ -57,7 +57,7 @@ const VSignupInputForm = ({
         type="password"
         placeholder="비밀번호를 입력해주세요."
         onChange={handleChange}
-        autocomplete="new-password"
+        autocomplete="off"
       />
       <InputGroup
         id="password-confirm"
@@ -65,7 +65,7 @@ const VSignupInputForm = ({
         type="password"
         placeholder="비밀번호를 한번 더 입력해주세요."
         onChange={handleChange}
-        autocomplete="new-password"
+        autocomplete="off"
       />
       {!passwordConfirm && (
         <div className="text-red-500">비밀번호가 일치하지 않습니다.</div>
@@ -76,7 +76,7 @@ const VSignupInputForm = ({
         type="text"
         placeholder="보호소 이름을 입력해주세요."
         onChange={handleChange}
-        autocomplete="organization"
+        autocomplete="off"
       />
       <InputGroup
         id="shelter-contact"
@@ -84,7 +84,7 @@ const VSignupInputForm = ({
         type="text"
         placeholder="보호소에 연락 가능한 연락처를 입력해주세요."
         onChange={handleChange}
-        autocomplete="tel-national"
+        autocomplete="off"
       />
       <AddressInputGroup />
       <button className="bg-brand-color text-white w-full rounded-md p-2">

--- a/src/pages/update/PatchStatusSelectGroup.tsx
+++ b/src/pages/update/PatchStatusSelectGroup.tsx
@@ -1,7 +1,7 @@
 import StatusScore from 'pages/register/StatusScore';
-import React, { useEffect, useState } from 'react';
-import { SetterOrUpdater, useSetRecoilState } from 'recoil';
-import registerState, { RegisterType } from 'recoil/registerState';
+import React, { useState } from 'react';
+import { SetterOrUpdater } from 'recoil';
+import { RegisterType } from 'recoil/registerState';
 
 interface PetStatusType {
   intelligence: number;
@@ -86,9 +86,10 @@ const PatchStatusSelectGroup = ({
     }
   };
 
-  useEffect(() => {
-    console.log(petStatus);
-  }, [petStatus]);
+  // 데이터 확인용
+  // useEffect(() => {
+  //   console.log(petStatus);
+  // }, [petStatus]);
 
   return (
     <div>

--- a/src/pages/update/PatchStatusSelectGroup.tsx
+++ b/src/pages/update/PatchStatusSelectGroup.tsx
@@ -1,7 +1,7 @@
 import StatusScore from 'pages/register/StatusScore';
 import React, { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
-import registerState from 'recoil/registerState';
+import { SetterOrUpdater, useSetRecoilState } from 'recoil';
+import registerState, { RegisterType } from 'recoil/registerState';
 
 interface PetStatusType {
   intelligence: number;
@@ -13,12 +13,13 @@ interface PetStatusType {
 
 interface PetStatusProps {
   petStatus: PetStatusType;
+  setUpdateState: SetterOrUpdater<RegisterType>;
 }
 
-const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
-  const [profileStatus, setProfileStatus] = useRecoilState(registerState);
-  const { petPolygonProfileDto } = profileStatus;
-
+const PatchStatusSelectGroup = ({
+  petStatus,
+  setUpdateState,
+}: PetStatusProps) => {
   const { intelligence, affinity, athletic, adaptability, activeness } =
     petStatus;
 
@@ -32,9 +33,9 @@ const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
     switch (status) {
       case 'intelligence':
         setIntelligenceOption(option);
-        setProfileStatus((prev) => ({
+        setUpdateState((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
             intelligence: option,
           },
@@ -42,9 +43,9 @@ const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
         break;
       case 'affinity':
         setAffinityOption(option);
-        setProfileStatus((prev) => ({
+        setUpdateState((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
             affinity: option,
           },
@@ -52,9 +53,9 @@ const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
         break;
       case 'athletic':
         setAthleticOption(option);
-        setProfileStatus((prev) => ({
+        setUpdateState((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
             athletic: option,
           },
@@ -62,9 +63,9 @@ const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
         break;
       case 'adaptability':
         setAdaptabilityOption(option);
-        setProfileStatus((prev) => ({
+        setUpdateState((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
             adaptability: option,
           },
@@ -72,9 +73,9 @@ const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
         break;
       case 'activeness':
         setActivenessOption(option);
-        setProfileStatus((prev) => ({
+        setUpdateState((prev) => ({
           ...prev,
-          polygonProfile: {
+          petPolygonProfileDto: {
             ...prev.petPolygonProfileDto,
             activeness: option,
           },
@@ -86,38 +87,38 @@ const PatchStatusSelectGroup = ({ petStatus }: PetStatusProps) => {
   };
 
   useEffect(() => {
-    console.log('propsData: ', petStatus);
-  }, []);
+    console.log(petStatus);
+  }, [petStatus]);
 
   return (
     <div>
       <StatusScore
         status={'intelligence'}
-        score={petPolygonProfileDto.intelligence}
+        score={intelligence}
         selectedOption={intelligenceOption}
         handleChange={handleOptionChange}
       />
       <StatusScore
         status={'affinity'}
-        score={petPolygonProfileDto.affinity}
+        score={affinity}
         selectedOption={affinityOption}
         handleChange={handleOptionChange}
       />
       <StatusScore
         status={'athletic'}
-        score={petPolygonProfileDto.athletic}
+        score={athletic}
         selectedOption={athleticOption}
         handleChange={handleOptionChange}
       />
       <StatusScore
         status={'adaptability'}
-        score={petPolygonProfileDto.adaptability}
+        score={adaptability}
         selectedOption={adaptabilityOption}
         handleChange={handleOptionChange}
       />
       <StatusScore
         status={'activeness'}
-        score={petPolygonProfileDto.activeness}
+        score={activeness}
         selectedOption={activenessOption}
         handleChange={handleOptionChange}
       />

--- a/src/pages/update/UpdatePage.tsx
+++ b/src/pages/update/UpdatePage.tsx
@@ -44,13 +44,15 @@ const UpdatePage = () => {
   useEffect(() => {
     if (!isLoading && data) {
       // 데이터 들어오는 것 확인 용도
-      console.log('data: ', data);
       console.log('status: ', updateState);
     }
   }, [updateState]);
 
   return !isLoading ? (
-    <PatchStatusSelectGroup petStatus={updateState.petPolygonProfileDto} />
+    <PatchStatusSelectGroup
+      petStatus={updateState.petPolygonProfileDto}
+      setUpdateState={setUpdateState}
+    />
   ) : (
     <div>Loading...</div>
   );

--- a/src/pages/update/UpdatePage.tsx
+++ b/src/pages/update/UpdatePage.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import registerState from 'recoil/registerState';
+import DayModalInput from 'pages/register/DayModalInput';
 import PatchStatusSelectGroup from './PatchStatusSelectGroup';
 
 const UpdatePage = () => {
@@ -41,18 +42,21 @@ const UpdatePage = () => {
     },
   });
 
+  // 데이터 들어오는 것 확인 용도
   useEffect(() => {
     if (!isLoading && data) {
-      // 데이터 들어오는 것 확인 용도
       console.log('status: ', updateState);
     }
   }, [updateState]);
 
   return !isLoading ? (
-    <PatchStatusSelectGroup
-      petStatus={updateState.petPolygonProfileDto}
-      setUpdateState={setUpdateState}
-    />
+    <div>
+      <DayModalInput />
+      <PatchStatusSelectGroup
+        petStatus={updateState.petPolygonProfileDto}
+        setUpdateState={setUpdateState}
+      />
+    </div>
   ) : (
     <div>Loading...</div>
   );


### PR DESCRIPTION
## 구현된 부분
- `Data Fetch 시 화면이 보일 때마다 GET 방식으로 fetch가 진행되는 문제`가 있어서 queryClient의 option을 추가했습니다. 만약 구현하시다가 이와 관련된 오류가 생기면 참고해주세요!!
- fetch된 데이터가 기본적으로 입력되어 있도록 했고, input을 읽기 전용으로 만들어서 onChange 문제, 타이핑 되는 문제 해결했습니다. 
- 로그인, 회원가입에서 텍스트 자동 완성 지원되었던 부분이 불필요하다고 판단하여 없앴습니다. 

## 미구현된 부분

## 고민
- StatusSelectGroup 컴포넌트를 재사용하려고 했으나, 기존 등록하기 페이지에서는 3점으로 보여주고 수정하기 페이지에서는 서버에서 받은 데이터를 보여줘서 새로운 컴포넌트를 만들었습니다. 
   - 반면, DayModal의 경우 새로운 컴포넌트를 만들 필요가 없어서 따로 만들지 않았습니다. 따로 추가될 기능은 없을 것 같긴한데 (통일성+향후 기능 추가)를 위해 새로운 컴포넌트가 있는게 나을까요? 