### PR TITLE
토큰 maxAge, expires 추가 및 로그인 안내 레이아웃 구현

### DIFF
--- a/src/commons/cookie/getUser.ts
+++ b/src/commons/cookie/getUser.ts
@@ -8,20 +8,6 @@ export const getLoginState = () => {
   return '로그인';
 };
 
-export const validateExpiredToken = () => {
-  const now = new Date();
-  const expiredDate = new Date(getCookie('expiredDate'));
-  console.log('만료 검사');
-
-  // 토큰만료 검사 후 삭제
-  if (now > expiredDate) {
-    removeCookie('loginToken');
-    removeCookie('expiredDate');
-    removeCookie('userAccountInfo');
-    console.log('토큰이 만료되어 삭제되었습니다.');
-  }
-};
-
 export const removeToken = () => {
   removeCookie('loginToken');
 };

--- a/src/commons/modals/LoginGuideModal.tsx
+++ b/src/commons/modals/LoginGuideModal.tsx
@@ -1,0 +1,47 @@
+import { useNavigate } from 'react-router-dom';
+
+interface ModalProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const LoginGuideModal = ({ isOpen, setIsOpen }: ModalProps) => {
+  const navigate = useNavigate();
+  if (!isOpen) {
+    return null;
+  }
+  return (
+    <dialog
+      className="flex justify-center h-[15vh] m-auto absolute bottom-6 rounded-lg border-2 border-gray-300 text-black"
+      open={isOpen}
+    >
+      <div className="modal-content w-[600px] flex flex-col gap-2 mt-4">
+        <div className="font-bold text-center">
+          <div>자동으로 로그아웃 되었습니다.</div>
+          <div>재로그인 하시겠습니까?</div>
+        </div>
+        <div className="flex gap-2 justify-around font-bold">
+          <button
+            className="border-brand-color text-brand-color border-2 rounded-md px-4 py-1 transition duration-300 hover:bg-brand-color hover:text-white"
+            onClick={() => {
+              navigate('/login');
+              setIsOpen(false);
+            }}
+          >
+            로그인 하기
+          </button>
+          <button
+            className="bg-brand-color text-white rounded-md px-4 py-1 transition duration-300 hover:bg-white hover:text-brand-color"
+            onClick={() => {
+              setIsOpen(false);
+            }}
+          >
+            로그아웃 유지하기
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+export default LoginGuideModal;

--- a/src/commons/modals/LoginGuideModal.tsx
+++ b/src/commons/modals/LoginGuideModal.tsx
@@ -1,3 +1,4 @@
+import { setCookie } from 'commons/cookie/cookie';
 import { useNavigate } from 'react-router-dom';
 
 interface ModalProps {
@@ -12,15 +13,15 @@ const LoginGuideModal = ({ isOpen, setIsOpen }: ModalProps) => {
   }
   return (
     <dialog
-      className="flex justify-center h-[15vh] m-auto absolute bottom-6 rounded-lg border-2 border-gray-300 text-black"
+      className="absolute z-50 flex justify-center h-[20vh] bottom-2 rounded-lg border-2 border-gray-300 text-black"
       open={isOpen}
     >
-      <div className="modal-content w-[600px] flex flex-col gap-2 mt-4">
-        <div className="font-bold text-center">
+      <div className="modal-content w-[600px] flex flex-col gap-4 justify-center">
+        <div className="font-bold text-center text-lg">
           <div>자동으로 로그아웃 되었습니다.</div>
           <div>재로그인 하시겠습니까?</div>
         </div>
-        <div className="flex gap-2 justify-around font-bold">
+        <div className="flex justify-evenly font-bold">
           <button
             className="border-brand-color text-brand-color border-2 rounded-md px-4 py-1 transition duration-300 hover:bg-brand-color hover:text-white"
             onClick={() => {
@@ -34,6 +35,7 @@ const LoginGuideModal = ({ isOpen, setIsOpen }: ModalProps) => {
             className="bg-brand-color text-white rounded-md px-4 py-1 transition duration-300 hover:bg-white hover:text-brand-color"
             onClick={() => {
               setIsOpen(false);
+              setCookie('userAccountInfo', 'Not Login');
             }}
           >
             로그아웃 유지하기

--- a/src/layouts/ValidateCheckLayout.tsx
+++ b/src/layouts/ValidateCheckLayout.tsx
@@ -18,7 +18,6 @@ const ValidateCheckLayout: React.FC<LayoutProps> = ({ children }) => {
       if (!loginToken && !userAccount) {
         // loginToken이 없으면 모달 열기
         setIsModalOpen(true);
-        setCookie('userAccountInfo', 'Not Login');
       }
     }, 60000);
 

--- a/src/layouts/ValidateCheckLayout.tsx
+++ b/src/layouts/ValidateCheckLayout.tsx
@@ -1,20 +1,103 @@
-import { validateExpiredToken } from 'commons/cookie/getUser';
-import React, { useEffect } from 'react';
-import { Routes } from 'react-router-dom';
+import { getCookie, setCookie } from 'commons/cookie/cookie';
+import LoginGuideModal from 'commons/modals/LoginGuideModal';
+import React, { useEffect, useState } from 'react';
+import { Route, Routes } from 'react-router-dom';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const ValidateCheckLayout: React.FC<LayoutProps> = ({ children }) => {
-  useEffect(() => {
-    validateExpiredToken();
-    const intervalId = setInterval(validateExpiredToken, 60000 * 30); // 30분에 한 번
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-    return () => clearInterval(intervalId);
+  useEffect(() => {
+    // 1분마다 loginToken이라는 이름의 쿠키가 있는지 검사
+    const checkTokenInterval = setInterval(() => {
+      const loginToken = getCookie('loginToken');
+      const userAccount = getCookie('userAccountInfo');
+      if (!loginToken && !userAccount) {
+        // loginToken이 없으면 모달 열기
+        setIsModalOpen(true);
+        setCookie('userAccountInfo', 'Not Login');
+      }
+    }, 60000);
+
+    return () => {
+      // 컴포넌트가 언마운트될 때 타이머를 정리
+      clearInterval(checkTokenInterval);
+    };
   }, []);
 
-  return <Routes>{children}</Routes>;
+  return (
+    <div>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/pet/:id"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/profile"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/shelter/:id/:page"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/profile/urgent/:page"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/profile/new/:page"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/register"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/find-shelter"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+        <Route
+          path="/pet-update/:id"
+          element={
+            <LoginGuideModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+          }
+        />
+        ;
+      </Routes>
+      <Routes>{children}</Routes>
+    </div>
+  );
 };
 
 export default ValidateCheckLayout;

--- a/src/pages/register/RegisterHeader.tsx
+++ b/src/pages/register/RegisterHeader.tsx
@@ -98,8 +98,7 @@ const RegisterHeader = () => {
   return (
     <>
       <div className="flex flex-col items-center gap-8">
-        <div className="flex justify-between items-center w-5/6">
-          <h1 className="text-center text-xl">등록하기</h1>
+        <div className="flex justify-end items-center w-5/6">
           <button
             onClick={() => setIsModalOpen(true)}
             className="bg-brand-color rounded-md font-bold text-white w-20 py-2"


### PR DESCRIPTION
## 구현된 기능
- 토큰이 없는지 1분마다 검사하여 없으면 모달창 띄우기
- 쿠키를 저장할 때 maxAge와 expires를 같이 옵션 값으로 저장

## 미구현된 기능

## 고민
- 토큰이 없어지면 바로 모달을 띄우고 싶은데, useEffect의 의존성 배열에 토큰 부분을 넣어도 작동이 안되어서 Interval 1분으로 구현했습니다. 이것보단 앞에 말한 방법이 더 좋을 것 같은데 어떻게 구현할 수 있을까요..?
- 레이아웃이 로그인, 회원가입 이외의 모든 곳에서 나오도록 되어있는데 사용자 입장에서 지도나 펫 리스트 등 토큰이 필요없는 화면에서도 그런 게 보일 필요가 있는지 고민입니다. 
- 레이아웃을 감쌀 때 경로를 하나하나 다 넣고 사용하고 있는데, "login, signup 이외 모든 경로" 이런 식으로 넣으면 더 깔끔할 것 같아서 방법 고민 중입니다. 🫠