### PR TITLE
지도 개선

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,10 +9,6 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <script
-      type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_KEY%&libraries=services,clusterer,drawing"
-    ></script>
     <link rel="stylesheet" type="text/css" href="/plugin/slick/slick.css"/>
     <link rel="stylesheet" type="text/css" href="/plugin/slick/slick-theme.css"/>
     

--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -17,7 +17,8 @@ declare global {
     kakao: any;
   }
 }
-const Map: React.FC = () => {
+
+const Map = () => {
   const mapRef = useRef<HTMLDivElement>(null);
   const [loading, setLoading] = useState(true);
   const { map, displayMarkerByInfo, searchedPlace, mutate, mutateData } =

--- a/src/pages/map/Map.tsx
+++ b/src/pages/map/Map.tsx
@@ -7,8 +7,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable no-new */
-import React, { useEffect, useRef } from 'react';
-import MapList, { SearchedPlace } from './MapList';
+import { useState, useEffect, useRef } from 'react';
+import MapList from './MapList';
+import MapSkeleton from './MapSkeleton';
 import useMap from './useMap';
 
 declare global {
@@ -18,8 +19,9 @@ declare global {
 }
 const Map: React.FC = () => {
   const mapRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(true);
   const { map, displayMarkerByInfo, searchedPlace, mutate, mutateData } =
-    useMap(mapRef);
+    useMap(mapRef, setLoading);
   useEffect(() => {
     mutate(searchedPlace);
   }, [searchedPlace]);
@@ -40,8 +42,9 @@ const Map: React.FC = () => {
 
   return (
     <div className="Map flex flex-col md:flex-row items-center justify-center gap-8">
-      <div ref={mapRef} className="w-96 h-96" />
-      <MapList searchedPlace={searchedPlace} map={map} />
+      <div ref={mapRef} className={`w-96 h-96 ${loading ? 'hidden' : ''}`} />
+      {loading && <MapSkeleton listSize={4} />}
+      <MapList searchedPlace={searchedPlace} map={map} loading={loading} />
     </div>
   );
 };

--- a/src/pages/map/MapList.tsx
+++ b/src/pages/map/MapList.tsx
@@ -22,10 +22,12 @@ export interface SearchedPlace {
 const MapList = ({
   searchedPlace,
   map,
+  loading,
 }: {
   searchedPlace: SearchedPlace[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   map: any;
+  loading: boolean;
 }) => {
   const { kakao } = window;
   const navigate = useNavigate();
@@ -44,6 +46,10 @@ const MapList = ({
     }
     return 0;
   });
+
+  if (loading) {
+    return <></>;
+  }
 
   return (
     <div className="w-96">

--- a/src/pages/map/MapList.tsx
+++ b/src/pages/map/MapList.tsx
@@ -24,6 +24,7 @@ const MapList = ({
   map,
 }: {
   searchedPlace: SearchedPlace[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   map: any;
 }) => {
   const { kakao } = window;
@@ -43,8 +44,6 @@ const MapList = ({
     }
     return 0;
   });
-
-  const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
 
   return (
     <div className="w-96">

--- a/src/pages/map/MapSkeleton.tsx
+++ b/src/pages/map/MapSkeleton.tsx
@@ -1,0 +1,17 @@
+const MapSkeleton = ({ listSize }: { listSize: number }) => {
+  return (
+    <>
+      <div className="w-96 h-96 bg-gray-100" />
+      <div className="w-96">
+        {Array.from({ length: listSize }).map((_, index) => (
+          <div
+            className="bg-gray-100 h-20 border rounded-md p-4 mb-2"
+            key={index}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default MapSkeleton;

--- a/src/pages/map/displayMarker.ts
+++ b/src/pages/map/displayMarker.ts
@@ -1,21 +1,7 @@
-export interface AddressInfo {
-  address_name: string;
-  category_group_code: string;
-  category_group_name: string;
-  category_name: string;
-  distance: string;
-  id: string;
-  phone: string;
-  place_name: string;
-  place_url: string;
-  road_address_name: string;
-  x: string;
-  y: string;
-  isRegistered: boolean;
-}
+import { SearchedPlace } from './MapList';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const displayMarker = async (map: any, addressInfo: AddressInfo) => {
+const displayMarker = async (map: any, addressInfo: SearchedPlace) => {
   const { kakao } = window;
   const { isRegistered, x: lng, y: lat, place_name: placeName } = addressInfo;
 

--- a/src/pages/map/displayMarker.ts
+++ b/src/pages/map/displayMarker.ts
@@ -1,7 +1,23 @@
-const displayMarker = async (map: any, addressInfo: any) => {
+export interface AddressInfo {
+  address_name: string;
+  category_group_code: string;
+  category_group_name: string;
+  category_name: string;
+  distance: string;
+  id: string;
+  phone: string;
+  place_name: string;
+  place_url: string;
+  road_address_name: string;
+  x: string;
+  y: string;
+  isRegistered: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const displayMarker = async (map: any, addressInfo: AddressInfo) => {
   const { kakao } = window;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { isRegistered, x: lng, y: lat, place_name } = addressInfo;
+  const { isRegistered, x: lng, y: lat, place_name: placeName } = addressInfo;
 
   const DEFAULT_SHELTER_SRC = '/assets/images/racoon.png';
   const ANYMORY_SHELTER_SRC = '/assets/images/dog.png';
@@ -25,7 +41,7 @@ const displayMarker = async (map: any, addressInfo: any) => {
   const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
   kakao.maps.event.addListener(marker, 'click', () => {
     infowindow.setContent(
-      `<div style="padding:5px;font-size:12px;">${place_name}</div>`,
+      `<div style="padding:5px;font-size:12px;">${placeName}</div>`,
     );
     infowindow.open(map, marker);
     setTimeout(() => {

--- a/src/pages/map/useMap.ts
+++ b/src/pages/map/useMap.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState, RefObject, useRef } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import displayMarker from './displayMarker';
+import displayMarker, { AddressInfo } from './displayMarker';
 
 function useMap<T>(
   containerRef: RefObject<T extends HTMLElement ? T : HTMLElement>,
@@ -12,7 +12,7 @@ function useMap<T>(
   const [searchedPlace, setSearchedPlace] = useState<any>([]);
   const boundRef = useRef<any>();
 
-  const displayMarkerByInfo = async (addressInfo: any) => {
+  const displayMarkerByInfo = async (addressInfo: AddressInfo) => {
     if (!map) return;
     map.setBounds(boundRef.current);
     await displayMarker(map, addressInfo);

--- a/src/pages/map/useMap.ts
+++ b/src/pages/map/useMap.ts
@@ -5,6 +5,7 @@ import displayMarker from './displayMarker';
 
 function useMap<T>(
   containerRef: RefObject<T extends HTMLElement ? T : HTMLElement>,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>,
 ) {
   const { kakao } = window;
   const [map, setMap] = useState<any>();
@@ -69,6 +70,7 @@ function useMap<T>(
           sort: kakao.maps.services.SortBy.DISTANCE,
         });
       });
+      setLoading(false);
     };
     mapScript.addEventListener('load', onLoadKakaoMap);
     onLoadKakaoMap();

--- a/src/pages/map/useMap.ts
+++ b/src/pages/map/useMap.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState, RefObject, useRef } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import displayMarker, { AddressInfo } from './displayMarker';
+import displayMarker from './displayMarker';
+import { SearchedPlace } from './MapList';
 
 function useMap<T>(
   containerRef: RefObject<T extends HTMLElement ? T : HTMLElement>,
@@ -12,7 +13,7 @@ function useMap<T>(
   const [searchedPlace, setSearchedPlace] = useState<any>([]);
   const boundRef = useRef<any>();
 
-  const displayMarkerByInfo = async (addressInfo: AddressInfo) => {
+  const displayMarkerByInfo = async (addressInfo: SearchedPlace) => {
     if (!map) return;
     map.setBounds(boundRef.current);
     await displayMarker(map, addressInfo);


### PR DESCRIPTION
## 구현된 부분
- 지도 페이지에 들어갔을 때 스크립트를 head에 append 하여 이전과 같이 홈에서부터 지도를 불러오지 않습니다.
따라서 이전처럼 사이트를 불러오는 데에 오랜 시간이 걸리지 않습니다.
![image](https://github.com/Step3-kakao-tech-campus/Team16_FE/assets/77186082/bdc708bc-6c19-4eab-894e-8181677ec8a8)
- 타 페이지에 있다가 '내 주변 보호소 찾기' 페이지로 이동해서야 스크립트를 호출하는 모습입니다.
![image](https://github.com/Step3-kakao-tech-campus/Team16_FE/assets/77186082/aab222af-7229-4396-bb7a-6ba88862b052)

- 지도에 스켈레톤 추가해주었습니다.

## 미구현 부분
- 타입 별도의 파일로 관리하기

## 고민
- X